### PR TITLE
feat(s7): support extended thinking blocks in conversation history

### DIFF
--- a/src/kama_claude/core/llm/provider.py
+++ b/src/kama_claude/core/llm/provider.py
@@ -140,16 +140,21 @@ class AnthropicProvider:
         )
 
         tool_calls: list[ToolCallBlock] = []
+        thinking_blocks: list[dict[str, object]] = []
         for block in final_message.content:
             if block.type == "tool_use":
                 tool_calls.append(
                     ToolCallBlock(id=block.id, name=block.name, input=dict(block.input))
                 )
+            elif block.type == "thinking":
+                # thinking blocks must be passed back verbatim in subsequent requests
+                thinking_blocks.append({"type": "thinking", "thinking": block.thinking, "signature": block.signature})
 
         return LlmResponse(
             stop_reason=final_message.stop_reason or "end_turn",
             tool_calls=tool_calls,
             text="".join(text_parts),
+            thinking_blocks=thinking_blocks,
             usage=UsageStats(
                 input_tokens=usage.input_tokens,
                 output_tokens=usage.output_tokens,

--- a/src/kama_claude/core/llm/types.py
+++ b/src/kama_claude/core/llm/types.py
@@ -25,3 +25,5 @@ class LlmResponse:
     tool_calls: list[ToolCallBlock] = field(default_factory=list)
     text: str = ""
     usage: UsageStats | None = None
+    # thinking blocks from extended thinking — must be preserved verbatim in conversation history
+    thinking_blocks: list[dict[str, object]] = field(default_factory=list)

--- a/src/kama_claude/core/loop.py
+++ b/src/kama_claude/core/loop.py
@@ -78,7 +78,8 @@ class AgentLoop:
                 break
 
             # [observe] append assistant content blocks to context
-            blocks: list[dict[str, object]] = []
+            # thinking blocks must come first and be preserved verbatim for extended thinking mode
+            blocks: list[dict[str, object]] = list(response.thinking_blocks)
             if response.text:
                 blocks.append({"type": "text", "text": response.text})
             for tc in response.tool_calls:


### PR DESCRIPTION
Preserve thinking blocks from LLM responses verbatim so subsequent requests in extended thinking mode receive the required context.