### PR TITLE
fix(mcp+transport): 修复 MCP 连接稳定性及 IPC 传输层问题

### DIFF
--- a/src/kama_claude/core/config.py
+++ b/src/kama_claude/core/config.py
@@ -85,22 +85,31 @@ class KamaConfig:
     mcp: McpConfig = field(default_factory=McpConfig)
 
 
-# 构建并返回运行时配置：默认值 → TOML → .env → 系统环境变量（后者优先级最高）
+# 构建并返回运行时配置：默认值 → 全局 TOML → 项目本地 TOML → .env → 系统环境变量（后者优先级最高）
 def get_config() -> KamaConfig:
     config = KamaConfig()
 
     # .env 必须在读取 KAMA_CONFIG 之前加载，以便 .env 中的 KAMA_CONFIG 能影响 TOML 路径
     load_dotenv(".env", override=False)
 
-    config_path = Path(os.environ.get("KAMA_CONFIG", _DEFAULT_CONFIG_PATH)).expanduser()
+    # 若显式指定 KAMA_CONFIG，只读该文件；否则按优先级叠加：全局 → 项目本地
+    explicit = os.environ.get("KAMA_CONFIG")
+    if explicit:
+        config_paths = [Path(explicit).expanduser()]
+    else:
+        config_paths = [
+            Path(_DEFAULT_CONFIG_PATH).expanduser(),
+            Path(".kama/config.toml"),
+        ]
 
-    if config_path.exists():
-        try:
-            with open(config_path, "rb") as f:
-                data = tomllib.load(f)
-        except tomllib.TOMLDecodeError as e:
-            raise SystemExit(f"Config parse error ({config_path}): {e}") from e
-        _apply_toml(config, data)
+    for config_path in config_paths:
+        if config_path.exists():
+            try:
+                with open(config_path, "rb") as f:
+                    data = tomllib.load(f)
+            except tomllib.TOMLDecodeError as e:
+                raise SystemExit(f"Config parse error ({config_path}): {e}") from e
+            _apply_toml(config, data)
 
     _apply_env(config)
     return config

--- a/src/kama_claude/core/mcp/client.py
+++ b/src/kama_claude/core/mcp/client.py
@@ -13,6 +13,11 @@ class McpServerUnavailableError(Exception):
     pass
 
 
+class McpToolError(Exception):
+    """MCP server 返回的应用层错误（连接正常，但工具调用失败）"""
+    pass
+
+
 @dataclass
 class McpToolDef:
     name: str
@@ -29,6 +34,9 @@ class McpClient:
         self._writer: asyncio.StreamWriter | None = None
         self._transport = ""
         self._lock = asyncio.Lock()
+        self._stderr_task: asyncio.Task[None] | None = None
+
+    _STREAM_LIMIT = 64 * 1024 * 1024  # 64 MB，防止大响应触发 LimitOverrunError
 
     # 启动 stdio 子进程并完成 MCP initialize 握手
     async def connect_stdio(
@@ -45,15 +53,18 @@ class McpClient:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=merged_env,
+            limit=self._STREAM_LIMIT,
         )
         self._reader = self._proc.stdout
         self._writer_proc = self._proc.stdin
         self._transport = "stdio"
+        # 后台持续读取 stderr，防止管道缓冲区满导致子进程阻塞
+        self._stderr_task = asyncio.create_task(self._drain_stderr())
         await self._initialize()
 
     # 通过 TCP 连接到 MCP server 并完成 initialize 握手
     async def connect_tcp(self, host: str, port: int) -> None:
-        self._reader, tcp_writer = await asyncio.open_connection(host, port)
+        self._reader, tcp_writer = await asyncio.open_connection(host, port, limit=self._STREAM_LIMIT)
         self._tcp_writer = tcp_writer
         self._transport = "tcp"
         await self._initialize()
@@ -79,21 +90,42 @@ class McpClient:
             ))
         return tools
 
-    # 调用 MCP server 上的工具，返回第一个 text 类型内容
+    # 调用 MCP server 上的工具，返回所有 text 内容拼接；连接异常抛 McpServerUnavailableError，工具错误抛 McpToolError
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
-        try:
-            response = await self._call("tools/call", {"name": name, "arguments": arguments})
-        except McpServerUnavailableError:
-            raise
-        except Exception as exc:
-            raise McpServerUnavailableError(str(exc)) from exc
+        response = await self._call("tools/call", {"name": name, "arguments": arguments})
+        parts: list[str] = []
         for item in response.get("content", []):
             if item.get("type") == "text":
-                return str(item["text"])
-        return ""
+                parts.append(str(item["text"]))
+        return "\n".join(parts)
+
+    # 后台任务：持续读取 stderr 并记录日志，防止管道缓冲区满
+    async def _drain_stderr(self) -> None:
+        if self._proc is None or self._proc.stderr is None:
+            return
+        try:
+            while True:
+                line = await self._proc.stderr.readline()
+                if not line:
+                    break
+                stderr_line = line.decode(errors="replace").rstrip()
+                if stderr_line:
+                    log.debug("mcp stderr: %s", stderr_line)
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            log.debug("mcp stderr drain stopped", exc_info=True)
 
     # 关闭连接并终止 stdio 子进程
     async def close(self) -> None:
+        # 先取消 stderr 读取任务
+        if self._stderr_task is not None:
+            self._stderr_task.cancel()
+            try:
+                await self._stderr_task
+            except asyncio.CancelledError:
+                pass
+            self._stderr_task = None
         if self._transport == "stdio" and self._proc is not None:
             try:
                 self._proc.terminate()
@@ -112,24 +144,32 @@ class McpClient:
                 except Exception:
                     pass
 
-    # 发送 JSON-RPC 请求并等待响应
+    # 发送 JSON-RPC 请求并等待响应；id 比较用字符串兼容服务端返回字符串 id 的情况
     async def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         self._id += 1
         req_id = self._id
+        req_id_str = str(req_id)
         request = {"jsonrpc": "2.0", "id": req_id, "method": method, "params": params}
         async with self._lock:
             await self._write_line(json.dumps(request))
             while True:
                 line = await self._read_line()
-                if not line:
-                    raise McpServerUnavailableError("MCP server closed connection")
                 try:
                     msg = json.loads(line)
                 except json.JSONDecodeError:
+                    log.debug("mcp: ignoring non-JSON line: %r", line[:200])
                     continue
-                if msg.get("id") == req_id:
+                msg_id = msg.get("id")
+                if msg_id is None:
+                    # server-initiated notification，忽略
+                    log.debug("mcp: received server notification: %s", msg.get("method"))
+                    continue
+                if str(msg_id) == req_id_str:
                     if "error" in msg:
-                        raise RuntimeError(f"MCP error: {msg['error']}")
+                        err = msg["error"]
+                        raise McpToolError(
+                            f"{err.get('message', str(err))} (code={err.get('code')})"
+                        )
                     result: dict[str, Any] = msg.get("result", {})
                     return result
 
@@ -154,12 +194,21 @@ class McpClient:
             w.write(data)
             await w.drain()
 
-    # 从 MCP server 读取一行 JSON（跳过空行）
+    # 从 MCP server 读取一行 JSON；跳过空行，仅 EOF（b""）才视为连接断开
     async def _read_line(self) -> str:
         if self._reader is None:
             raise McpServerUnavailableError("reader unavailable")
-        try:
-            data = await asyncio.wait_for(self._reader.readline(), timeout=30.0)
-        except TimeoutError:
-            raise McpServerUnavailableError("MCP server read timeout")
-        return data.decode().strip()
+        while True:
+            try:
+                data = await asyncio.wait_for(self._reader.readline(), timeout=30.0)
+            except TimeoutError:
+                raise McpServerUnavailableError("MCP server read timeout")
+            except asyncio.LimitOverrunError as exc:
+                raise McpServerUnavailableError(
+                    f"MCP response too large (>{self._STREAM_LIMIT // 1024 // 1024}MB): {exc}"
+                ) from exc
+            if data == b"":
+                raise McpServerUnavailableError("MCP server closed connection")
+            line = data.decode(errors="replace").strip()
+            if line:
+                return line

--- a/src/kama_claude/core/mcp/tool.py
+++ b/src/kama_claude/core/mcp/tool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from kama_claude.core.mcp.client import McpClient, McpServerUnavailableError, McpToolDef
+from kama_claude.core.mcp.client import McpClient, McpServerUnavailableError, McpToolDef, McpToolError
 from kama_claude.core.tools.base import BaseTool, ToolResult
 
 
@@ -21,20 +21,26 @@ class McpTool(BaseTool):
             tool_def.input_schema or {"type": "object", "properties": {}}
         )
 
-    # 调用 MCP server 上的工具，服务不可用时返回 is_error=True
+    # 调用 MCP server 上的工具，连接不可用或工具执行失败时返回 is_error=True
     async def invoke(self, params: dict[str, object]) -> ToolResult:
         try:
             content = await self._client.call_tool(self._tool_def.name, dict(params))
             return ToolResult(content=content)
-        except McpServerUnavailableError:
+        except McpServerUnavailableError as exc:
             return ToolResult(
-                content=f"mcp server '{self._server_name}' unavailable",
+                content=f"mcp server '{self._server_name}' unavailable: {exc}",
+                is_error=True,
+                error_type="runtime_error",
+            )
+        except McpToolError as exc:
+            return ToolResult(
+                content=f"mcp tool '{self.name}' error: {exc}",
                 is_error=True,
                 error_type="runtime_error",
             )
         except Exception as exc:
             return ToolResult(
-                content=str(exc),
+                content=f"mcp tool '{self.name}' unexpected error: {exc}",
                 is_error=True,
                 error_type="runtime_error",
             )

--- a/src/kama_claude/core/transport/socket_client.py
+++ b/src/kama_claude/core/transport/socket_client.py
@@ -10,7 +10,7 @@ from kama_claude.core.bus.envelope import JsonRpcRequest
 
 type EventHandler = Callable[[dict[str, Any]], Awaitable[None]]
 
-_MAX_LINE_BYTES = 1 * 1024 * 1024  # 1 MB per frame
+_MAX_LINE_BYTES = 64 * 1024 * 1024  # 64 MB per frame，兼容 MCP 大文件工具结果
 
 
 class IpcError(RuntimeError):
@@ -69,6 +69,9 @@ class SocketClient:
                     line = await self._reader.readline()
                 except (ConnectionResetError, OSError):
                     break
+                except (ValueError, asyncio.LimitOverrunError):
+                    # 单行超出 limit；丢弃本行，继续读取后续消息
+                    continue
                 if not line:
                     break
                 await self._dispatch(line)

--- a/src/kama_claude/core/transport/socket_server.py
+++ b/src/kama_claude/core/transport/socket_server.py
@@ -41,7 +41,7 @@ def _now() -> str:
 def get_connection_writer() -> asyncio.StreamWriter:
     return _writer_var.get()
 
-_MAX_LINE_BYTES = 1 * 1024 * 1024  # 1 MB per frame
+_MAX_LINE_BYTES = 64 * 1024 * 1024  # 64 MB per frame，兼容 MCP 大文件工具结果
 
 
 class SocketServer:
@@ -58,6 +58,7 @@ class SocketServer:
         self._server: asyncio.AbstractServer | None = None
         self._broadcaster = broadcaster
         self._trace = trace
+        self._active_writers: set[asyncio.StreamWriter] = set()
 
     # 注册一个方法名对应的命令处理函数
     def register(self, method: str, handler: CommandHandler) -> None:
@@ -81,12 +82,20 @@ class SocketServer:
         )
         return f"{self._host}:{self._port}"
 
-    # 关闭服务器，最多等待 2 秒
+    # 关闭服务器：先断开所有活跃连接，再等待服务器完全关闭（最多 2 秒）
     async def stop(self) -> None:
         if self._server is None:
             return
+        for writer in list(self._active_writers):
+            try:
+                writer.close()
+            except Exception:
+                pass
         self._server.close()
-        await asyncio.wait_for(self._server.wait_closed(), timeout=2.0)
+        try:
+            await asyncio.wait_for(self._server.wait_closed(), timeout=2.0)
+        except (TimeoutError, asyncio.CancelledError):
+            pass
 
     # 处理单个客户端连接，完成后关闭写流
     async def _handle_connection(
@@ -96,15 +105,16 @@ class SocketServer:
     ) -> None:
         peer = writer.get_extra_info("peername", "<unknown>")
         logger.debug("client connected: %s", peer)
+        self._active_writers.add(writer)
         try:
             await self._read_loop(reader, writer)
         finally:
+            self._active_writers.discard(writer)
             if self._broadcaster is not None:
                 self._broadcaster.unsubscribe(writer)
-            writer.close()
             try:
-                await asyncio.wait_for(writer.wait_closed(), timeout=1.0)
-            except (TimeoutError, ConnectionResetError, BrokenPipeError, OSError):
+                writer.close()
+            except Exception:
                 pass
             logger.debug("client disconnected: %s", peer)
 


### PR DESCRIPTION
- config: 支持叠加读取项目本地 .kama/config.toml（优先级高于全局）
- mcp/client: 新增 McpToolError 区分连接错误与工具执行错误；修复空行误判为 EOF； id 比较改为字符串兼容服务端返回字符串 id；stdio/tcp 连接 limit 提升至 64 MB； 补充 stderr drain task 防止子进程阻塞
- mcp/tool: 错误信息携带真实原因，区分 unavailable / tool error / unexpected error
- transport/socket_client: limit 提升至 64 MB；捕获 ValueError/LimitOverrunError 防止超大事件导致 kama-tui 崩溃
- transport/socket_server: Ctrl+C 关闭时先断开活跃连接再 stop；移除 wait_closed() 避免对端强制断开时触发 "Unhandled exception in client_connected_cb"