### PR TITLE
fix(s6): preserve compacted history and escape tool output

### DIFF
--- a/src/kama_claude/core/compact/compactor.py
+++ b/src/kama_claude/core/compact/compactor.py
@@ -84,6 +84,7 @@ class Compactor:
             {"role": "user", "content": result.summary_text},
             {"role": "assistant", "content": "Understood, I'll continue from this summary."},
         ]
+        context.compacted = True
         self._write_summary(result.summary_text)
         await self._bus.publish(
             ContextCompactedEvent(

--- a/src/kama_claude/core/context.py
+++ b/src/kama_claude/core/context.py
@@ -18,6 +18,8 @@ class ExecutionContext:
     status: str = "running"  # "running" | "success" | "failed"
     reason: str | None = None
     result: str = ""
+    # True after compact replaces the message list, so the runner must rewrite persistence.
+    compacted: bool = False
 
     # 初始化消息历史，优先使用 session 完整回放内容
     def __post_init__(self) -> None:

--- a/src/kama_claude/core/runner.py
+++ b/src/kama_claude/core/runner.py
@@ -190,7 +190,11 @@ class AgentRunner:
             )
 
         if session is not None and store is not None:
-            store.append_messages(session.id, context.messages[prefill_len:], run_id=run_id)
+            if context.compacted:
+                # Compact replaces message positions; persist the rebuilt history.
+                store.write_compacted(session.id, context.messages)
+            else:
+                store.append_messages(session.id, context.messages[prefill_len:], run_id=run_id)
 
         if cancelled:
             raise asyncio.CancelledError()

--- a/src/kama_claude/tui/app.py
+++ b/src/kama_claude/tui/app.py
@@ -8,6 +8,7 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 from rich.markdown import Markdown
+from rich.markup import escape
 from textual import events
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -103,9 +104,9 @@ class ToolCallBlock(Widget):
             return f"  [green]remembered[/green]  [dim]{self._elapsed_ms}ms[/dim]"
 
         params_pre = _param_summary(self._tool_name, self._params)
-        line = f"  [dim]tool[/dim] [bold]{self._tool_name}[/bold]"
+        line = f"  [dim]tool[/dim] [bold]{escape(self._tool_name)}[/bold]"
         if params_pre:
-            line += f"  [dim]{params_pre}[/dim]"
+            line += f"  [dim]{escape(params_pre)}[/dim]"
         if self._finished:
             color = "red" if self._is_error else "green"
             status = "failed" if self._is_error else "done"
@@ -131,8 +132,8 @@ class ToolCallBlock(Widget):
         else:
             detail = self.query_one(".detail", Static)
             detail.update(
-                f"[dim]params[/dim]\n{self._params_full}\n\n"
-                f"[dim]output[/dim]\n{self._output}\n\n"
+                f"[dim]params[/dim]\n{escape(self._params_full)}\n\n"
+                f"[dim]output[/dim]\n{escape(self._output)}\n\n"
                 f"[dim]elapsed:[/dim] {self._elapsed_ms}ms"
             )
             self.add_class("expanded")

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from kama_claude.core.config import KamaConfig
 from kama_claude.core.events.bus import EventBus
-from kama_claude.core.llm.types import LlmResponse, ToolCallBlock
+from kama_claude.core.llm.types import LlmResponse, ToolCallBlock, UsageStats
 from kama_claude.core.runner import AgentRunner
 
 # --- mock provider -----------------------------------------------------------
@@ -71,6 +71,38 @@ class _CapturingProvider:
         self.messages = [dict(m) for m in messages]
         self.system = system
         return self.response
+
+
+class _AutoCompactingProvider:
+    """Triggers one automatic compact, then finishes the run."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def chat(
+        self,
+        messages: list[dict[str, object]],
+        tool_schemas: list[dict[str, object]],
+        bus: EventBus,
+        run_id: str,
+        *,
+        step: int = 0,
+        system: str | None = None,
+    ) -> LlmResponse:
+        self.calls += 1
+        if run_id == "compact":
+            return LlmResponse(
+                stop_reason="end_turn",
+                text="COMPACT SUMMARY",
+                usage=UsageStats(input_tokens=100, output_tokens=20),
+            )
+        if self.calls == 1:
+            return LlmResponse(
+                stop_reason="tool_use",
+                tool_calls=[ToolCallBlock(id="unknown-1", name="unknown_tool", input={})],
+                usage=UsageStats(input_tokens=900, output_tokens=10, context_pct=0.9),
+            )
+        return LlmResponse(stop_reason="end_turn", text="final answer")
 
 
 # --- helpers -----------------------------------------------------------------
@@ -256,6 +288,44 @@ async def test_session_history_and_notes_injected(tmp_path: Path) -> None:
     assert "Python 3.12" in provider.system
     assert (store.runs_dir("sess-1") / "run-new" / "events.jsonl").exists()
     assert not (tmp_path / "runs" / "run-new").exists()
+
+
+# 功能：验证自动 compact 后完整重写 thread，而不是使用旧 prefill_len 切片
+# 设计：compact 将初始历史替换为摘要后继续完成 run，摘要和后续消息都必须持久化
+async def test_auto_compact_rewrites_full_session_history(tmp_path: Path) -> None:
+    from kama_claude.core.session.model import Session
+    from kama_claude.core.session.store import SessionStore
+
+    store = SessionStore(tmp_path / "sessions")
+    session = Session(
+        id="sess-compact",
+        mode="chat",
+        status="active",
+        title="",
+        created_at="t",
+        updated_at="t",
+    )
+    store.write_meta(session)
+    store.append_message(session.id, "user", "original goal")
+
+    config = _config(max_steps=3)
+    config.compaction.auto_threshold = 0.8
+    runner = AgentRunner(
+        config,
+        provider=_AutoCompactingProvider(),  # type: ignore[arg-type]
+        runs_dir=tmp_path / "runs",
+    )
+
+    await runner.run_and_capture(
+        "original goal",
+        run_id="run-compact",
+        session=session,
+        store=store,
+    )
+
+    messages = store.read_messages(session.id)
+    assert messages[0]["content"] == "COMPACT SUMMARY"
+    assert messages[-1]["content"] == [{"type": "text", "text": "final answer"}]
 
 
 # 功能：验证 session run 中注册了 note_save，工具调用会写入 notes.md

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from rich.markdown import Markdown
+from rich.markup import escape
+from rich.text import Text
 from textual.widget import Widget
 
 from kama_claude.tui.app import (
@@ -147,6 +149,28 @@ def test_tool_call_started_and_finished() -> None:
     assert isinstance(block, ToolCallBlock)
     assert block._finished  # type: ignore[attr-defined]
     assert block._output == "hi"  # type: ignore[attr-defined]
+
+
+# 功能：验证工具详情中的原始输出不会被 Rich 当作 markup 解析
+# 设计：模拟文件内容包含非法关闭标签，展开详情后交给 Rich 解析不应抛 MarkupError
+def test_tool_detail_escapes_raw_markup(monkeypatch) -> None:
+    class _Detail:
+        rendered: str = ""
+
+        def update(self, content: str) -> None:
+            self.rendered = content
+
+    raw = "source = '[/{color}]'"
+    detail = _Detail()
+    block = ToolCallBlock("read_file", {"path": "src/kama_claude/tui/app.py"})
+    block.set_result(raw, 1)
+    monkeypatch.setattr(block, "query_one", lambda *_args: detail)
+    monkeypatch.setattr(block, "add_class", lambda *_args: None)
+
+    block.on_click()
+
+    assert escape(raw) in detail.rendered
+    Text.from_markup(detail.rendered)
 
 
 # 功能：验证 note_save 成功完成时工具块摘要显示 remembered


### PR DESCRIPTION
## 问题

### 1. TUI 展开工具详情时崩溃

工具输出会被直接拼接到 Rich markup 字符串中。若文件内容包含类似：

```text
[/{color}]
```

Rich 会将其误认为格式标签，导致：

```text
MarkupError: closing tag does not match any open tag
```
## 错误截图

<img width="929" height="646" alt="屏幕截图 2026-08-15 010217" src="https://github.com/user-attachments/assets/4781ccf1-aecf-45c1-b888-55faccea0de0" />

### 2. 自动 compact 后消息持久化不完整

run 开始时会记录旧消息列表长度 `prefill_len`。自动 compact 会整体替换 `context.messages`，使原来的消息下标失效。

run 结束后仍执行：

```python
context.messages[prefill_len:]
```

因此 compact 后的新摘要或本轮新增消息，可能无法正确写入 `thread.jsonl`。

## 解决方法

### 1. 转义工具输出

使用 `rich.markup.escape()` 转义工具名、参数和输出，再交给 Rich 渲染，避免原始内容被当作 markup 解析。

### 2. 标记消息是否被 compact 重构

在 `ExecutionContext` 中增加状态字段：

```python
compacted: bool = False
```

当 compact 成功替换消息列表后，将其设置为 `True`。

run 结束时根据该状态选择持久化策略：

- 未发生 compact：继续使用 `context.messages[prefill_len:]` 增量追加本轮消息。
- 已发生 compact：调用 `write_compacted()`，将重构后的完整会话历史写入 `thread.jsonl`。

## 测试

新增以下测试：

- 工具输出包含原始 Rich markup 时，展开 TUI 工具详情不会抛出 `MarkupError`。
- 自动 compact 后，摘要与本轮后续消息都会正确持久化到会话历史。

测试结果：

```text
25 passed
```